### PR TITLE
Remove chai as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "gulp-fibre-tasks": "^1.3.0"
   },
   "dependencies": {
-    "chai": "^2.3.0",
     "jdataview": "^2.5.0",
     "lodash": "^3.8.0",
     "pg-crypt": "^0.10.0",


### PR DESCRIPTION
Doesn't appear to be in use, and causes dependency problems for me upstream
